### PR TITLE
Add simple Bohr atom simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bohr Atom Modeli Simülasyonu</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Bohr Atom Modeli Simülasyonu</h1>
+  <div id="controls">
+    <label for="nSelect">Enerji Seviyesi (n):</label>
+    <select id="nSelect">
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+      <option value="4">4</option>
+    </select>
+    <label for="tempSlider">Sıcaklık (K):</label>
+    <input type="range" id="tempSlider" min="0" max="5000" value="300">
+    <span id="tempValue">300K</span>
+  </div>
+  <canvas id="simCanvas"></canvas>
+  <div id="info">
+    <p>Seviye: <span id="levelInfo"></span></p>
+    <p>Enerji: <span id="energyInfo"></span></p>
+    <p>Enerji Farkı: <span id="deltaEInfo"></span></p>
+    <p>Foton Dalga Boyu: <span id="lambdaInfo"></span></p>
+  </div>
+  <div id="explanations">
+    <h2>Bohr Modeli Nedir?</h2>
+    <p>Bohr modeli, elektronlarin belirli enerji seviyelerinde dairesel yörüngelerde dolandigini söyler.</p>
+    <p>Elektronlar yalnızca belirli enerji değerlerini alabilir; bu değerlere kuantum enerji seviyeleri denir.</p>
+    <h2>Elektron Enerji Seviyeleri</h2>
+    <p>n arttıkça elektron çekirdekten uzaklaşır ve enerjisi artar.</p>
+  </div>
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,34 @@
+import { AtomSimulation } from './simulation/AtomSimulation.js';
+
+const canvas = document.getElementById('simCanvas');
+const nSelect = document.getElementById('nSelect');
+const tempSlider = document.getElementById('tempSlider');
+const tempValue = document.getElementById('tempValue');
+const levelInfo = document.getElementById('levelInfo');
+const energyInfo = document.getElementById('energyInfo');
+const deltaEInfo = document.getElementById('deltaEInfo');
+const lambdaInfo = document.getElementById('lambdaInfo');
+
+const sim = new AtomSimulation(canvas, {
+  onUpdate(info) {
+    levelInfo.textContent = info.n;
+    energyInfo.textContent = info.energy.toFixed(2) + ' eV';
+    deltaEInfo.textContent = info.deltaE ? info.deltaE.toFixed(2) + ' eV' : '-';
+    lambdaInfo.textContent = info.lambda ? info.lambda.toFixed(0) + ' nm' : '-';
+  }
+});
+
+nSelect.addEventListener('change', () => {
+  const n = parseInt(nSelect.value, 10);
+  sim.setLevel(n);
+});
+
+tempSlider.addEventListener('input', () => {
+  tempValue.textContent = tempSlider.value + 'K';
+  sim.setTemperature(parseInt(tempSlider.value, 10));
+});
+
+window.addEventListener('resize', () => sim.resize());
+
+tempValue.textContent = tempSlider.value + 'K';
+sim.start();

--- a/simulation/Atom.js
+++ b/simulation/Atom.js
@@ -1,0 +1,7 @@
+import { Electron } from './Electron.js';
+
+export class Atom {
+  constructor() {
+    this.electron = new Electron(1);
+  }
+}

--- a/simulation/AtomSimulation.js
+++ b/simulation/AtomSimulation.js
@@ -1,0 +1,151 @@
+ import { Atom } from "./Atom.js";
+import { Electron } from "./Electron.js";
+import { Photon } from "./Photon.js";
+
+export class AtomSimulation {
+  constructor(canvas, callbacks = {}) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.callbacks = callbacks;
+
+    this.width = canvas.clientWidth;
+    this.height = canvas.clientHeight;
+
+    this.center = { x: this.width / 2, y: this.height / 2 };
+
+    this.levelColors = [ "#a6cee3", "#b2df8a", "#fb9a99", "#fdbf6f" ];
+    this.atom = new Atom();
+    this.electron = this.atom.electron;
+
+    this.n = this.electron.n;
+    this.targetN = this.electron.n;
+    this.energy = this.electron.energy();
+    this.temperature = 300;
+
+    this.animationTime = 1000; // ms
+    this.lastUpdate = null;
+    this.electronAngle = 0;
+    this.animating = false;
+    this.deltaE = null;
+    this.lambda = null;
+  }
+
+  start() {
+    this.resize();
+    requestAnimationFrame( time => this.loop(time) );
+  }
+
+  resize() {
+    this.width = this.canvas.clientWidth;
+    this.height = this.canvas.clientHeight;
+    this.canvas.width = this.width;
+    this.canvas.height = this.height;
+    this.center = { x: this.width / 2, y: this.height / 2 };
+  }
+
+  loop(time) {
+    if ( !this.lastUpdate ) this.lastUpdate = time;
+    const dt = time - this.lastUpdate;
+    this.lastUpdate = time;
+
+    // random thermal excitation based on temperature
+    if (Math.random() < this.temperature / 1e6) {
+      const next = Math.min(4, this.n + 1);
+      if (next !== this.n) this.setLevel(next);
+    }
+
+    this.update(dt);
+    this.draw();
+    requestAnimationFrame( t => this.loop(t) );
+  }
+
+  energyForLevel(n) {
+    return -13.6 / (n * n);
+  }
+
+  setTemperature(temp) {
+    this.temperature = temp;
+  }
+
+  setLevel(n) {
+    if (n === this.n) return;
+    this.targetN = n;
+    this.deltaE = this.energyForLevel(n) - this.energyForLevel(this.n);
+    this.photon = new Photon(this.deltaE);
+    this.lambda = this.photon.lambda;
+    this.animating = true;
+    this.animationElapsed = 0;
+  }
+
+  update(dt) {
+    if (this.animating) {
+      this.animationElapsed += dt;
+      const progress = Math.min(this.animationElapsed / this.animationTime, 1);
+      if (progress >= 1) {
+        this.animating = false;
+        this.electron.n = this.targetN;
+        this.n = this.electron.n;
+        this.energy = this.electron.energy();
+        this.deltaE = null;
+        this.lambda = null;
+        this.photon = null;
+      }
+    }
+
+    this.electronAngle += dt * 0.001; // constant angular velocity
+    if (this.electronAngle > Math.PI * 2) this.electronAngle -= Math.PI * 2;
+
+    if (this.callbacks.onUpdate) {
+      this.callbacks.onUpdate({
+        n: this.n,
+        energy: this.energy,
+        deltaE: this.deltaE,
+        lambda: this.lambda
+      });
+    }
+  }
+
+  draw() {
+    const ctx = this.ctx;
+    ctx.clearRect(0, 0, this.width, this.height);
+
+    // draw nucleus
+    ctx.fillStyle = '#888';
+    ctx.beginPath();
+    ctx.arc(this.center.x, this.center.y, 10, 0, Math.PI * 2);
+    ctx.fill();
+
+    // draw orbits
+    for (let i = 1; i <= 4; i++) {
+      ctx.strokeStyle = this.levelColors[i - 1];
+      ctx.beginPath();
+      ctx.arc(this.center.x, this.center.y, 40 * i, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+
+    const progress = this.animating ? Math.min(this.animationElapsed / this.animationTime, 1) : 1;
+    // compute electron radius (interpolated during animation)
+    const targetRadius = 40 * this.targetN;
+    const currentRadius = this.electron.radius();
+    const radius = currentRadius + (targetRadius - currentRadius) * progress;
+
+    // draw photon if animating
+    if (this.animating) {
+      ctx.strokeStyle = this.photon.color;
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(this.center.x, this.center.y - currentRadius);
+      ctx.lineTo(this.center.x, this.center.y - radius);
+      ctx.stroke();
+    }
+
+    // draw electron
+    const angle = this.electronAngle;
+    const x = this.center.x + radius * Math.cos(angle);
+    const y = this.center.y + radius * Math.sin(angle);
+    ctx.fillStyle = '#000';
+    ctx.beginPath();
+    ctx.arc(x, y, 5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}

--- a/simulation/Electron.js
+++ b/simulation/Electron.js
@@ -1,0 +1,13 @@
+export class Electron {
+  constructor(n = 1) {
+    this.n = n;
+  }
+
+  radius() {
+    return 40 * this.n;
+  }
+
+  energy() {
+    return -13.6 / (this.n * this.n);
+  }
+}

--- a/simulation/Photon.js
+++ b/simulation/Photon.js
@@ -1,0 +1,8 @@
+export class Photon {
+  constructor(deltaE) {
+    this.deltaE = deltaE;
+    const hc = 1240; // eV*nm
+    this.lambda = Math.abs(hc / deltaE);
+    this.color = deltaE > 0 ? 'red' : 'blue';
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,20 @@
+body {
+  font-family: sans-serif;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+}
+#controls {
+  margin: 1em;
+}
+#simCanvas {
+  width: 100%;
+  max-width: 600px;
+  height: 400px;
+  border: 1px solid #ccc;
+  display: block;
+  margin: 0 auto;
+}
+#info {
+  margin-top: 1em;
+}


### PR DESCRIPTION
## Summary
- create initial HTML with controls and info panel
- implement `AtomSimulation` and supporting classes
- add main JS entry wiring UI to the simulation
- basic styling for canvas and controls

## Testing
- `node --check main.js`
- `node --check simulation/AtomSimulation.js`
- `node --check simulation/Atom.js`
- `node --check simulation/Electron.js`
- `node --check simulation/Photon.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68494ea23468832ab6d32f0913f29dc3