### PR TITLE
Add basic Compton scattering simulation

### DIFF
--- a/compton-sim/README.md
+++ b/compton-sim/README.md
@@ -1,0 +1,14 @@
+# Compton Saçılması Simülasyonu
+
+Bu basit simülasyon, MEB (K12) müfredatına uygun olarak Compton saçılmasını görsel olarak açıklamak için tasarlanmıştır. Mobil ve web uyumlu olacak şekilde basit HTML ve JavaScript kullanılmıştır.
+
+## Kullanım
+
+1. `index.html` dosyasını modern bir tarayıcıda açın.
+2. "Saçılma Açısı" ve "Fototun Başlangıç Dalga Boyu" kaydırıcılarını kullanarak parametreleri değiştirin.
+3. Ekrandaki grafik ve sonuç değeri anlık olarak güncellenir.
+
+Simülasyonda kullanılan formül:
+\[ \lambda' = \lambda_0 + \lambda_c (1 - \cos\theta) \]
+
+Burada \( \lambda_c \) Compton dalga boyu (2.43×10⁻¹² m) olup değerler nanometre cinsinden verilmiştir.

--- a/compton-sim/index.html
+++ b/compton-sim/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Compton Saçılması Simülasyonu</title>
+<style>
+  body { font-family: Arial, sans-serif; margin: 0; padding: 0; text-align: center; }
+  canvas { background: #f8f8f8; width: 100%; height: auto; max-width: 600px; }
+  .controls { margin-top: 10px; }
+  label { display: block; margin-top: 8px; }
+</style>
+</head>
+<body>
+<h2>Compton Saçılması (MEB K12 Uyumlu)</h2>
+<canvas id="simCanvas" width="600" height="400"></canvas>
+<div class="controls">
+  <label>Saçılma Açısı: <span id="angleValue">45</span>°
+    <input type="range" id="angle" min="0" max="180" value="45">
+  </label>
+  <label>Fototun Başlangıç Dalga Boyu (nm): <span id="lambdaValue">0.1</span>
+    <input type="range" id="lambda" min="0.05" max="0.5" step="0.01" value="0.1">
+  </label>
+  <p>Saçılma Sonrası Dalga Boyu: <span id="result">0</span> nm</p>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/compton-sim/script.js
+++ b/compton-sim/script.js
@@ -1,0 +1,75 @@
+const canvas = document.getElementById('simCanvas');
+const ctx = canvas.getContext('2d');
+const angleInput = document.getElementById('angle');
+const lambdaInput = document.getElementById('lambda');
+const angleValue = document.getElementById('angleValue');
+const lambdaValue = document.getElementById('lambdaValue');
+const resultSpan = document.getElementById('result');
+
+// Compton sabiti (nm)
+const LAMBDA_C = 0.00243; // 2.43e-12 m = 0.00243 nm
+
+function computeScatteredLambda(lambda0, angle) {
+  const radians = angle * Math.PI / 180;
+  return lambda0 + LAMBDA_C * (1 - Math.cos(radians));
+}
+
+function drawSimulation() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  // Başlangıç fotonu
+  ctx.strokeStyle = 'blue';
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(50, canvas.height / 2);
+  ctx.lineTo(250, canvas.height / 2);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.arc(250, canvas.height / 2, 5, 0, 2 * Math.PI);
+  ctx.fillStyle = 'blue';
+  ctx.fill();
+
+  // Elektron
+  ctx.fillStyle = 'red';
+  ctx.beginPath();
+  ctx.arc(300, canvas.height / 2, 10, 0, 2 * Math.PI);
+  ctx.fill();
+
+  const angle = parseFloat(angleInput.value);
+  const finalLambda = computeScatteredLambda(parseFloat(lambdaInput.value), angle);
+  resultSpan.textContent = finalLambda.toFixed(3);
+
+  angleValue.textContent = angle;
+  lambdaValue.textContent = lambdaInput.value;
+
+  // Saçılan foton
+  const length = 150;
+  const rad = angle * Math.PI / 180;
+  const startX = 300;
+  const startY = canvas.height / 2;
+  const endX = startX + length * Math.cos(rad);
+  const endY = startY - length * Math.sin(rad);
+
+  ctx.strokeStyle = 'green';
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(startX, startY);
+  ctx.lineTo(endX, endY);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.arc(endX, endY, 5, 0, 2 * Math.PI);
+  ctx.fillStyle = 'green';
+  ctx.fill();
+
+  // Saçılan elektron (basitleştirilmiş yön)
+  ctx.strokeStyle = 'orange';
+  ctx.beginPath();
+  ctx.moveTo(startX, startY);
+  ctx.lineTo(startX - length * 0.4, startY + length * Math.sin(rad) * 0.4);
+  ctx.stroke();
+}
+
+angleInput.addEventListener('input', drawSimulation);
+lambdaInput.addEventListener('input', drawSimulation);
+window.addEventListener('load', drawSimulation);


### PR DESCRIPTION
## Summary
- implement a simple Compton scattering simulator with HTML canvas
- include a README with usage instructions

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68496baa0cf8832a8b0c07b53ede0557